### PR TITLE
Add support for PUT and DELETE requests

### DIFF
--- a/samples/GrpcShared/product_catalog.proto
+++ b/samples/GrpcShared/product_catalog.proto
@@ -7,6 +7,7 @@ package ProductCatalog;
 service Product {
   rpc GetProducts (GetProductsRequest) returns (GetProductsReply) {}
   rpc CreateProduct (CreateProductRequest) returns (CreateProductReply) {}
+  rpc UpdateProduct (UpdateProductRequest) returns (UpdateProductReply) {}
 }
 
 message GetProductsRequest {
@@ -23,6 +24,17 @@ message CreateProductRequest {
 }
 
 message CreateProductReply {
+  ProductDto product = 1;
+}
+
+message UpdateProductRequest {
+  int32 id = 1;
+  string name = 2;
+  int32 quantity = 3;
+  string description = 4;
+}
+
+message UpdateProductReply {
   ProductDto product = 1;
 }
 

--- a/samples/GrpcShared/product_catalog.proto
+++ b/samples/GrpcShared/product_catalog.proto
@@ -8,6 +8,7 @@ service Product {
   rpc GetProducts (GetProductsRequest) returns (GetProductsReply) {}
   rpc CreateProduct (CreateProductRequest) returns (CreateProductReply) {}
   rpc UpdateProduct (UpdateProductRequest) returns (UpdateProductReply) {}
+  rpc DeleteProduct (DeleteProductRequest) returns (DeleteProductReply) {}
 }
 
 message GetProductsRequest {
@@ -35,6 +36,14 @@ message UpdateProductRequest {
 }
 
 message UpdateProductReply {
+  ProductDto product = 1;
+}
+
+message DeleteProductRequest {
+  int32 id = 1;
+}
+
+message DeleteProductReply {
   ProductDto product = 1;
 }
 

--- a/samples/OcelotGateway/appsettings.Development.json
+++ b/samples/OcelotGateway/appsettings.Development.json
@@ -16,6 +16,10 @@
       {
         "GrpcMethod": "/ProductCatalog.Product/UpdateProduct",
         "GrpcHost": "cataloggrpc:80"
+      },
+      {
+        "GrpcMethod": "/ProductCatalog.Product/DeleteProduct",
+        "GrpcHost": "cataloggrpc:80"
       }
     ]
   },

--- a/samples/OcelotGateway/appsettings.Development.json
+++ b/samples/OcelotGateway/appsettings.Development.json
@@ -12,6 +12,10 @@
       {
         "GrpcMethod": "/ProductCatalog.Product/CreateProduct",
         "GrpcHost": "cataloggrpc:80"
+      },
+      {
+        "GrpcMethod": "/ProductCatalog.Product/UpdateProduct",
+        "GrpcHost": "cataloggrpc:80"
       }
     ]
   },

--- a/samples/OcelotGateway/ocelot.Development.json
+++ b/samples/OcelotGateway/ocelot.Development.json
@@ -44,6 +44,25 @@
       }
     },
     {
+      "UpstreamPathTemplate": "/products/{id}",
+      "UpstreamHttpMethod": [ "Put" ],
+      "DownstreamPathTemplate": "/ProductCatalog.Product/UpdateProduct",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 5002
+        },
+        {
+          "Host": "localhost",
+          "Port": 50022
+        }
+      ],
+      "LoadBalancerOptions": {
+        "Type": "RoundRobin"
+      }
+    },
+    {
       "DownstreamPathTemplate": "/todos",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/samples/OcelotGateway/ocelot.Development.json
+++ b/samples/OcelotGateway/ocelot.Development.json
@@ -63,6 +63,25 @@
       }
     },
     {
+      "UpstreamPathTemplate": "/products/{id}",
+      "UpstreamHttpMethod": [ "Delete" ],
+      "DownstreamPathTemplate": "/ProductCatalog.Product/DeleteProduct",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 5002
+        },
+        {
+          "Host": "localhost",
+          "Port": 50022
+        }
+      ],
+      "LoadBalancerOptions": {
+        "Type": "RoundRobin"
+      }
+    },
+    {
       "DownstreamPathTemplate": "/todos",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/samples/OcelotGateway/ocelot.json
+++ b/samples/OcelotGateway/ocelot.json
@@ -55,6 +55,21 @@
       }
     },
     {
+      "UpstreamPathTemplate": "/products/{id}",
+      "UpstreamHttpMethod": [ "Delete" ],
+      "DownstreamPathTemplate": "/ProductCatalog.Product/DeleteProduct",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "productserver",
+          "Port": 80
+        }
+      ],
+      "LoadBalancerOptions": {
+        "Type": "LeastConnection"
+      }
+    },
+    {
       "DownstreamPathTemplate": "/todos",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/samples/OcelotGateway/ocelot.json
+++ b/samples/OcelotGateway/ocelot.json
@@ -40,6 +40,21 @@
       }
     },
     {
+      "UpstreamPathTemplate": "/products/{id}",
+      "UpstreamHttpMethod": [ "Put" ],
+      "DownstreamPathTemplate": "/ProductCatalog.Product/UpdateProduct",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "productserver",
+          "Port": 80
+        }
+      ],
+      "LoadBalancerOptions": {
+        "Type": "LeastConnection"
+      }
+    },
+    {
       "DownstreamPathTemplate": "/todos",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/samples/ProductGrpcServer/Services/ProductService.cs
+++ b/samples/ProductGrpcServer/Services/ProductService.cs
@@ -62,5 +62,19 @@ namespace ProductGrpcServer.Services
                 }
             });
         }
+
+        public override async Task<DeleteProductReply> DeleteProduct(DeleteProductRequest request, ServerCallContext context)
+        {
+            return await Task.FromResult(new DeleteProductReply
+            {
+                Product = new ProductDto
+                {
+                    Id = request.Id,
+                    Name = "Deleted Product",
+                    Quantity = new Random().Next(100),
+                    Description = $"Deleted product with ID {request.Id}"
+                }
+            });
+        }
     }
 }

--- a/samples/ProductGrpcServer/Services/ProductService.cs
+++ b/samples/ProductGrpcServer/Services/ProductService.cs
@@ -48,5 +48,19 @@ namespace ProductGrpcServer.Services
                 }
             });
         }
+
+        public override async Task<UpdateProductReply> UpdateProduct(UpdateProductRequest request, ServerCallContext context)
+        {
+            return await Task.FromResult(new UpdateProductReply
+            {
+                Product = new ProductDto
+                {
+                    Id = request.Id,
+                    Name = $"{request.Name} updated",
+                    Quantity = request.Quantity,
+                    Description = $"{request.Description} updated"
+                }
+            });
+        }
     }
 }

--- a/src/GrpcJsonTranscoder/DownStreamContextExtensions.cs
+++ b/src/GrpcJsonTranscoder/DownStreamContextExtensions.cs
@@ -47,7 +47,8 @@ namespace GrpcJsonTranscoder
                     switch (context.HttpContext.Request.Method.ToLowerInvariant())
                     {
                         case "get":
-                            requestData = context.HttpContext.ParseGetJsonRequest(upstreamHeaders);
+                        case "delete":
+                            requestData = context.HttpContext.ParseGetOrDeleteJsonRequest(upstreamHeaders);
                             break;
                         case "put":
                             requestData = context.HttpContext.ParsePutJsonRequest(upstreamHeaders);

--- a/src/GrpcJsonTranscoder/DownStreamContextExtensions.cs
+++ b/src/GrpcJsonTranscoder/DownStreamContextExtensions.cs
@@ -43,13 +43,18 @@ namespace GrpcJsonTranscoder
                                 { "x-grpc-route-data", JsonConvert.SerializeObject(context.TemplatePlaceholderNameAndValues.Select(x => new {x.Name, x.Value})) },
                                 { "x-grpc-body-data", await context.DownstreamRequest.Content.ReadAsStringAsync() }
                             };
-                    if (context.HttpContext.Request.Method.ToLowerInvariant() == "get")
+
+                    switch (context.HttpContext.Request.Method.ToLowerInvariant())
                     {
-                        requestData = context.HttpContext.ParseGetJsonRequest(upstreamHeaders);
-                    }
-                    else
-                    {
-                        requestData = context.HttpContext.ParseOtherJsonRequest(upstreamHeaders);
+                        case "get":
+                            requestData = context.HttpContext.ParseGetJsonRequest(upstreamHeaders);
+                            break;
+                        case "put":
+                            requestData = context.HttpContext.ParsePutJsonRequest(upstreamHeaders);
+                            break;
+                        default:
+                            requestData = context.HttpContext.ParseOtherJsonRequest(upstreamHeaders);
+                            break;
                     }
 
                     var loadBalancerFactory = context.HttpContext.RequestServices.GetService<ILoadBalancerFactory>();

--- a/src/GrpcJsonTranscoder/Internal/Http/HttpContextExtensions.cs
+++ b/src/GrpcJsonTranscoder/Internal/Http/HttpContextExtensions.cs
@@ -12,7 +12,7 @@ namespace GrpcJsonTranscoder.Internal.Http
 {
     internal static class HttpContextExtensions
     {
-        public static string ParseGetJsonRequest(this HttpContext context, IDictionary<string, string> upstreamHeaders = null)
+        public static string ParseGetOrDeleteJsonRequest(this HttpContext context, IDictionary<string, string> upstreamHeaders = null)
         {
             var o = new JObject();
 
@@ -75,7 +75,7 @@ namespace GrpcJsonTranscoder.Internal.Http
             return JsonConvert.SerializeObject(o);
         }
 
-        public static string ParseGetJsonRequestOnAggregateService(this HttpContext context)
+        public static string ParseGetOrDeleteJsonRequestOnAggregateService(this HttpContext context)
         {
             var o = new JObject();
 

--- a/src/GrpcJsonTranscoder/Internal/Middleware/GrpcJsonTranscoderMiddleware.cs
+++ b/src/GrpcJsonTranscoder/Internal/Middleware/GrpcJsonTranscoderMiddleware.cs
@@ -33,7 +33,8 @@ namespace GrpcJsonTranscoder.Internal.Middleware
                     switch (context.Request.Method.ToLowerInvariant())
                     {
                         case "get":
-                            requestData = context.ParseGetJsonRequestOnAggregateService();
+                        case "delete":
+                            requestData = context.ParseGetOrDeleteJsonRequestOnAggregateService();
                             break;
                         case "put":
                             requestData = await context.ParsePutJsonRequestOnAggregateService();

--- a/src/GrpcJsonTranscoder/Internal/Middleware/GrpcJsonTranscoderMiddleware.cs
+++ b/src/GrpcJsonTranscoder/Internal/Middleware/GrpcJsonTranscoderMiddleware.cs
@@ -30,13 +30,17 @@ namespace GrpcJsonTranscoder.Internal.Middleware
                 else
                 {
                     string requestData;
-                    if (context.Request.Method.ToLowerInvariant() == "get")
+                    switch (context.Request.Method.ToLowerInvariant())
                     {
-                        requestData = context.ParseGetJsonRequestOnAggregateService();
-                    }
-                    else
-                    {
-                        requestData = await context.ParseOtherJsonRequestOnAggregateService();
+                        case "get":
+                            requestData = context.ParseGetJsonRequestOnAggregateService();
+                            break;
+                        case "put":
+                            requestData = await context.ParsePutJsonRequestOnAggregateService();
+                            break;
+                        default:
+                            requestData = await context.ParseOtherJsonRequestOnAggregateService();
+                            break;
                     }
 
                     var grpcLookupTable = options.Value.GrpcMappers;


### PR DESCRIPTION
For PUT requests, the library will parse both the `x-grpc-route-data` and `x-grpc-body-data` upstream headers and merges them into a single JSON object to be sent to the appropriate gRPC service. For DELETE requests, the parser for GET requests is used (where only `x-grpc-route-data` is parsed).

To help test these new features, I've added an `UpdateProduct` method and a `DeleteProduct` method in the Product gRPC service. The Ocelot configuration and appsettings in the OcelotGateway sample project have also been updated to recognise these new methods. The methods can be accessed by making a `PUT` or `DELETE` request to `/products/{id}`.

Closes #6.