### PR TITLE
migration to .NET 5 And Ocelot 15.0.6 - change mehod name to method fullname

### DIFF
--- a/samples/OcelotGateway/OcelotGateway.csproj
+++ b/samples/OcelotGateway/OcelotGateway.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Ocelot" Version="14.0.11" />
+	  <PackageReference Include="Ocelot" Version="15.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GrpcJsonTranscoder/DownStreamContextExtensions.cs
+++ b/src/GrpcJsonTranscoder/DownStreamContextExtensions.cs
@@ -32,7 +32,7 @@ namespace GrpcJsonTranscoder
             {
                 var methodPath = context.DownstreamReRoute.DownstreamPathTemplate.Value;
                 var grpcAssemblyResolver = context.HttpContext.RequestServices.GetService<GrpcAssemblyResolver>();
-                var methodDescriptor = grpcAssemblyResolver.FindMethodDescriptor(methodPath.Split('/').Last().ToUpperInvariant());
+                var methodDescriptor = grpcAssemblyResolver.FindMethodDescriptor(methodPath.TrimStart('/').Replace("/", ".").Last().ToUpperInvariant());
 
                 if (methodDescriptor == null)
                 {

--- a/src/GrpcJsonTranscoder/Grpc/GrpcAssemblyResolver.cs
+++ b/src/GrpcJsonTranscoder/Grpc/GrpcAssemblyResolver.cs
@@ -66,7 +66,7 @@ namespace GrpcJsonTranscoder.Grpc
                     foreach (var method in svr.Methods)
                     {
                         _logger.LogInformation($"Add method name #{method.Name.ToUpper()} into the assembly resolver.");
-                        methodDescriptorDic.TryAdd(method.Name.ToUpper(), method);
+                        methodDescriptorDic.TryAdd(method.FullName.ToUpper(), method);
                     }
                 }
             }

--- a/src/GrpcJsonTranscoder/GrpcJsonTranscoder.csproj
+++ b/src/GrpcJsonTranscoder/GrpcJsonTranscoder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <!--<SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>GrpcJsonTranscoder.pfx</AssemblyOriginatorKeyFile>-->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -17,16 +17,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.11.4" />
-    <PackageReference Include="Grpc.Core" Version="2.27.0" />
-    <PackageReference Include="Grpc.Reflection" Version="2.27.0" />
-    <PackageReference Include="Ocelot" Version="14.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+	  <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+	  <PackageReference Include="Grpc.Core" Version="2.42.0" />
+	  <PackageReference Include="Grpc.Reflection" Version="2.42.0" />
+	  <PackageReference Include="Ocelot" Version="15.0.6" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
+	  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
+	  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
migration to .NET 5 And Ocelot 15.0.6 - change mehod name to method fullname